### PR TITLE
Fixing xferfaxlog formatting (quotes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+debian/debhelper-build-stamp
+debian/files
+debian/gofaxip.debhelper.log
+debian/gofaxip.postinst.debhelper
+debian/gofaxip.postrm.debhelper
+debian/gofaxip.prerm.debhelper
+debian/gofaxip.substvars
+debian/gofaxip/
+obj-x86_64-linux-gnu/
+

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ go get github.com/gonicus/gofaxip/...
 
 This will produce the binaries `gofaxd` and `gofaxsend`.
 
+## Build debian package
+```
+git clone https://github.com/gonicus/gofaxip
+cd gofaxip
+apt install dh-golang dh-systemd git-buildpackage
+git-buildpackage
+```
+
 ## Installation
 
 We recommend running GOfax.IP on Debian 8 ("Jessie"), so these instructions cover Debian in detail. Of course it is possible to install and use GOfax.IP on other Linux distributions and possibly other Unixes supported by golang, FreeSWITCH and HylaFAX.

--- a/gofaxlib/xferfaxlog.go
+++ b/gofaxlib/xferfaxlog.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// 19 fields
-	xLogFormat = "%s\t%s\t%s\t%s\t%v\t%s\t%s\t\"%s\"\t\"%s\"\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\"%s\""
+	xLogFormat = "%s\t%s\t%s\t%s\t%v\t\"%s\"\t%s\t\"%s\"\t\"%s\"\t%d\t%d\t%s\t%s\t\"%s\"\t\"%s\"\t\"%s\"\t\"%s\"\t\"%s\"\t\"%s\""
 	tsLayout   = "01/02/06 15:04"
 )
 


### PR DESCRIPTION
Some software are parsing xferfaxlog output, but gofaxip does not do the exact same format as hylafax does by default.

This pull request will add quoting as hylafax does in it's xferfaxlog output.

I've also included some help to build debian package. You've maybe forgotten to push the upstream branches to github in order for others to build their packages.