### PR TITLE
Add ability to override dialstring variables for destinations using mod_db entries

### DIFF
--- a/gofaxlib/fsdb.go
+++ b/gofaxlib/fsdb.go
@@ -2,6 +2,8 @@ package gofaxlib
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/fiorix/go-eventsocket/eventsocket"
 )
 
@@ -40,4 +42,14 @@ func FreeSwitchDBExists(c *eventsocket.Connection, realm string, key string) (bo
 	}
 
 	return result.Body == "true", nil
+}
+
+// FreeSwitchDBList returns a list of all keys in given realm
+// If realm is empty, a list of all realms is returned
+func FreeSwitchDBList(c *eventsocket.Connection, realm string) ([]string, error) {
+	result, err := c.Send(fmt.Sprintf("api db list/%s", realm))
+	if err != nil {
+		return []string{}, err
+	}
+	return strings.Split(result.Body, ","), nil
 }


### PR DESCRIPTION
To help debugging transmissions to certain destinations, dialstring variables that should be applied only to faxes for the given destination can be added to FreeSWITCH's db:

```
db insert/override-4711/fax_verbose/true
```
Realm must be a string starting with `override-` and the exact destination number.