### PR TITLE
Refactor gofaxsend into a package

### DIFF
--- a/gofaxsend/cmd/main.go
+++ b/gofaxsend/cmd/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gonicus/gofaxip/gofaxlib"
 	"github.com/gonicus/gofaxip/gofaxlib/logger"
+	"github.com/gonicus/gofaxip/gofaxsend"
 )
 
 const (
@@ -73,18 +74,17 @@ func main() {
 
 	qfilename := flag.Arg(0)
 	if qfilename == "" {
-		logger.Logger.Println("No qfile provided on command line")
-		os.Exit(sendFailed)
+		logger.Logger.Fatalln("No qfile provided on command line")
 	}
 
 	gofaxlib.LoadConfig(*configFile)
 	devicefifo := filepath.Join(gofaxlib.Config.Hylafax.Spooldir, fifoPrefix+*deviceID)
 	gofaxlib.SendFIFO(devicefifo, "SB")
 
-	returned, err := SendQfile(qfilename)
+	returned, err := gofaxsend.SendQfileFromDisk(qfilename, *deviceID)
 	if err != nil {
 		logger.Logger.Printf("Error processing qfile %v: %v", qfilename, err)
-		returned = sendFailed
+		returned = gofaxsend.SendFailed
 	}
 
 	gofaxlib.SendFIFO(devicefifo, "SR")
@@ -94,5 +94,5 @@ func main() {
 	}
 
 	logger.Logger.Print("Exiting with status ", returned)
-	os.Exit(returned)
+	os.Exit(int(returned))
 }

--- a/gofaxsend/error.go
+++ b/gofaxsend/error.go
@@ -15,7 +15,7 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-package main
+package gofaxsend
 
 // FaxError is a Error including information if a fax shoud be retried
 type FaxError interface {

--- a/gofaxsend/faxfile.go
+++ b/gofaxsend/faxfile.go
@@ -15,7 +15,7 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-package main
+package gofaxsend
 
 import (
 	"errors"

--- a/gofaxsend/faxjob.go
+++ b/gofaxsend/faxjob.go
@@ -15,7 +15,7 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-package main
+package gofaxsend
 
 import (
 	"github.com/google/uuid"

--- a/gofaxsend/qfile.go
+++ b/gofaxsend/qfile.go
@@ -15,7 +15,7 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-package main
+package gofaxsend
 
 import (
 	"bufio"

--- a/gofaxsend/qfile_test.go
+++ b/gofaxsend/qfile_test.go
@@ -1,4 +1,4 @@
-package main
+package gofaxsend
 
 import (
 	"testing"

--- a/gofaxsend/transmission.go
+++ b/gofaxsend/transmission.go
@@ -15,7 +15,7 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-package main
+package gofaxsend
 
 import (
 	"bytes"


### PR DESCRIPTION
Using the idiomatic Go convention of writing code in a package,
and then handle the CLI in a smaller main-package.

This makes the code importable from other parts of the code and
more maintainable.

In the spirit of portability, also split SendQfile into a separate
function that uses the Qfile reference without requiring the use
of the filesystem.