### PR TITLE
Implement in-memory variant of Qfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.10
+      - image: circleci/golang:latest
 
     working_directory: /go/src/github.com/gonicus/gofaxip
     steps:

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Markus Lindenberg <lindenberg@gonicus.de>
 Sebastian Denz <denz@gonicus.de>
 Julian Kornberger <jk+github@digineo.de>
 Steffen Jaeckel <gh@jaeckel.eu>
+Etienne Bruines <e.bruines@q-mex.net>

--- a/gofaxsend/qmemory.go
+++ b/gofaxsend/qmemory.go
@@ -1,0 +1,64 @@
+package gofaxsend
+
+import (
+	"errors"
+	"strconv"
+)
+
+// Qmemory provides the same functionality as Qfile, but all in-memory. It implements Qfiler.
+type Qmemory struct {
+	params map[string][]string
+
+}
+
+// NewQmemory instantiates a new Qmemory with the given parameters.
+func NewQmemory(parameters map[string][]string) *Qmemory {
+	if parameters == nil {
+		parameters = make(map[string][]string)
+	}
+	return &Qmemory{
+		params: parameters,
+	}
+}
+
+func (q Qmemory) Write() error {
+	// no-op
+	return nil
+}
+
+func (q Qmemory) GetAll(tag string) []string {
+	res, ok := q.params[tag]
+	if !ok {
+		return []string{}
+	}
+
+	return res
+}
+
+func (q Qmemory) GetString(tag string) string {
+	res, ok := q.params[tag]
+	if !ok {
+		return ""
+	}
+
+	return res[0]
+}
+
+func (q Qmemory) GetInt(tag string) (int, error) {
+	v := q.GetString(tag)
+	if v == "" {
+		return 0, errors.New("tag not found")
+	}
+
+	return strconv.Atoi(v)
+}
+
+func (q Qmemory) Set(tag, value string) {
+	q.params[tag] = []string{value}
+}
+
+func (q Qmemory) Add(tag, value string) {
+	existing, _ := q.params[tag]
+	q.params[tag] = append(existing, value)
+}
+

--- a/gofaxsend/qmemory_test.go
+++ b/gofaxsend/qmemory_test.go
@@ -6,25 +6,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestOpenQfile(t *testing.T) {
+func TestNewQmemory(t *testing.T) {
 	assert := assert.New(t)
-	file, err := OpenQfile("testdata/qfile")
 
-	// Make sure it implements Qfiler
-	var qfiler Qfiler = file
-	assert.NotNil(qfiler)
+	values := map[string][]string{}
+	var mem1 Qfiler = NewQmemory(values)
+	assert.NotNil(mem1)
+
+	var mem2 Qfiler = NewQmemory(nil)
+	assert.NotNil(mem2)
+
+	// Make sure we can use the internal map, that it is not nil and therefore does not panic
+	mem2.Set("foo", "bar")
+}
+
+func TestQmemory(t *testing.T) {
+	assert := assert.New(t)
+	file := NewQmemory(map[string][]string{
+		"number": {"04012345678"},
+		"priority": {"127"},
+		"sender": {"Max Mustermann"},
+	})
 
 	// Loading successful?
-	assert.NoError(err)
 	assert.NotNil(file)
-	assert.Len(file.params, 71)
 
 	// Existing string value
 	assert.Equal("04012345678", file.GetString("number"))
 	assert.EqualValues([]string{"04012345678"}, file.GetAll("number"))
 
 	// Non-existing string value
-	assert.Nil(file.GetAll("non-existing"))
+	assert.Empty(file.GetAll("non-existing"))
 	assert.Equal("", file.GetString("non-existing"))
 
 	// Existing int value
@@ -51,6 +63,6 @@ func TestOpenQfile(t *testing.T) {
 	file.Set("baz", "foo")
 	assert.Equal("baz", file.GetString("foo"))
 
-	// Close
-	assert.NoError(file.Close())
+	// Write
+	assert.NoError(file.Write())
 }

--- a/gofaxsend/sendqfile.go
+++ b/gofaxsend/sendqfile.go
@@ -55,7 +55,7 @@ func SendQfileFromDisk(filename, deviceID string) (SendResult, error) {
 }
 
 // SendQfile immediately tries to send the given qfile using FreeSWITCH
-func SendQfile(qf *Qfile, deviceID string) (returned SendResult, err error) {
+func SendQfile(qf Qfiler, deviceID string) (returned SendResult, err error) {
 	returned = SendFailed
 
 	var jobid uint


### PR DESCRIPTION
As part of unifying the interface, I also made sure the "Add"
function of Qfile actually does what it describes in the doc:
creating the value if the tag does not yet exist.

Close is not part of the Qfiler interface, because (1) only the
Qfile itself needs it, and (2) because the SendQfile function
does not call it: it is only used by the SendQfileFromDisk,
function which does not use the Qfiler interface but the Qfile
directly.

Updated tests accordingly.