### PR TITLE
Updates for Debian 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To have `faxstat` show modem/channel usage in it's status output, a modem config
 If `/etc/gofax.conf` is configured to manage 5 (virtual) modems, you have to create the (empty) configuration files manually:
 
 ```
-sudo touch /var/spool/hylafax/etc/config.freeswitch{0..4}
+sudo touch /etc/hylafax/config.freeswitch{0..4}
 ```
 
 ## Operation

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ After you created the api token you can continue with adding the repository
 
 ```
 TOKEN=YOURSIGNALWIRETOKEN
- 
+
 apt-get update && apt-get install -y gnupg2 wget lsb-release
- 
+
 wget --http-user=signalwire --http-password=$TOKEN -O /usr/share/keyrings/signalwire-freeswitch-repo.gpg https://freeswitch.signalwire.com/repo/deb/debian-release/signalwire-freeswitch-repo.gpg
- 
+
 echo "machine freeswitch.signalwire.com login signalwire password $TOKEN" > /etc/apt/auth.conf
 echo "deb [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list
 echo "deb-src [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ `lsb_release -sc` main" >> /etc/apt/sources.list.d/freeswitch.list
- 
+
 apt-get update
 ```
 
@@ -139,7 +139,7 @@ As the _virtual modems_ visible in HylaFAX are not tied to preconfigured lines b
 ### DynamicConfig for incoming faxes
 
 `DynamicConfig` as used and documented in HylaFAX can be used by GOfax.IP. 
-One option per line can be set, comments are not allowed. 
+One option per line can be set, comments are not allowed.
 
 **Parameters**
 The following arguments are provided to the `DynamicConfig` script for incoming faxes:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+gofaxip (1.4-1) unstable; urgency=medium
+
+  * allow extraction of recipient from SIP Diversion Header
+  * improve logging
+  * adapt to hylafax changes from Debian 12
+  * allow configuration of final hangupcauses
+
+ -- Sebastian Denz <denz@gonicus.de>  Fri, 15 Mar 2024 09:03:57 +0100
+
 gofaxip (1.3-1) unstable; urgency=medium
 
   * allow prefix overriding from dynamicconfigoutgoing

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,6 @@ Uploaders: Markus Lindenberg <lindenberg@gonicus.de>
 Build-Depends: debhelper (>= 9),
                dh-golang,
                golang-go,
-               dh-systemd (>= 1.5)
 Standards-Version: 3.9.7
 Homepage: https://github.com/gonicus/gofaxip
 XS-Go-Import-Path: github.com/gonicus/gofaxip

--- a/debian/service
+++ b/debian/service
@@ -5,6 +5,7 @@ After=network.target local-fs.target
 [Service]
 User=uucp
 ExecStart=/usr/bin/gofaxd
+BindPaths=/etc/hylafax:/var/spool/hylafax/etc
 Restart=always
 
 [Install]

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian:bookworm
-MAINTAINER Markus Lindenberg <markus@lindenberg.io>
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBIAN_PRIORITY critical

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 MAINTAINER Markus Lindenberg <markus@lindenberg.io>
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/packaging/generate_packages.sh
+++ b/packaging/generate_packages.sh
@@ -7,6 +7,6 @@ else
     version="master"
 fi
 
-docker pull debian:buster
+docker pull debian:bookworm
 docker build -t gofaxip_build .
 docker run --rm -v $PWD/..:/input -v $PWD:/output -e VERSION=$version gofaxip_build


### PR DESCRIPTION
Hylafax in Debian Bookworm uses systemd Bindpaths instead of chroot (and copying files), so gofaxd needs to adapt that.